### PR TITLE
use client component Timer in server component About page

### DIFF
--- a/app/about/page.jsx
+++ b/app/about/page.jsx
@@ -1,3 +1,5 @@
+import Timer from "./timer";
+
 export default function AboutPage() {
   return (
     <>
@@ -6,6 +8,9 @@ export default function AboutPage() {
         chantastic's is building a creative coding community
         around curiosity and kindness.
       </p>
+      <span>
+        This time is from a a client component: <Timer />
+      </span>
     </>
   );
 }

--- a/app/about/timer.jsx
+++ b/app/about/timer.jsx
@@ -1,0 +1,17 @@
+"use client";
+
+import * as React from "react";
+
+export default function Timer() {
+  let [seconds, updateSeconds] = React.useState(0);
+
+  React.useEffect(() => {
+    const intervalId = setInterval(() => {
+      updateSeconds(seconds + 1);
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [seconds]);
+
+  return <>{seconds}</>;
+}


### PR DESCRIPTION
The Next app directory uses server components by default.

But we can create client components with the "use client" directive.
Server components can import client components.
https://beta.nextjs.org/docs/rendering/server-and-client-components#client-components

This adds a client component timer to the server component page.