### PR TITLE
add about layout

### DIFF
--- a/app/about/layout.jsx
+++ b/app/about/layout.jsx
@@ -1,0 +1,12 @@
+export default function Layout({ children }) {
+  return (
+    <>
+      <header>
+        <nav>
+          <a href="/">Home</a>
+        </nav>
+      </header>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/app/about/layout.jsx
+++ b/app/about/layout.jsx
@@ -3,7 +3,17 @@ export default function Layout({ children }) {
     <>
       <header>
         <nav>
-          <a href="/">Home</a>
+          <ol>
+            <li>
+              <a href="/">Home</a>
+            </li>
+            <li>
+              <a href="/about">About</a>
+            </li>
+            <li>
+              <a href="/about/nested">About (nested)</a>
+            </li>
+          </ol>
         </nav>
       </header>
       <main>{children}</main>

--- a/app/about/nested/page.jsx
+++ b/app/about/nested/page.jsx
@@ -1,0 +1,7 @@
+export default function NestedAbout() {
+  return (
+    <p>
+      Any page in this directory gets `/about/layout.jsx` layout
+    </p>
+  );
+}


### PR DESCRIPTION
Add a layout component for `/about*` routes.
Reference docs: https://beta.nextjs.org/docs/routing/pages-and-layouts#layouts

- add layout to /about* routes
- add /about/nested to show how pages use nearest layout
